### PR TITLE
Optimize dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
 FROM python:3.6-alpine
 
 ENV CONFIG_FILE=/code/config.yaml
+ENV PIP_NO_CACHE_DIR=false
+
 
 RUN mkdir /code
-ADD . /code
 WORKDIR /code
 
-RUN apk add build-base jpeg-dev zlib-dev graphviz-dev postgresql-dev musl-dev gcc && \
+COPY Pipfile Pipfile.lock ./
+
+RUN apk add --no-cache --virtual .deps build-base jpeg-dev zlib-dev graphviz-dev musl-dev gcc postgresql-dev && \
     pip install pipenv && \
-    pipenv lock && \
-    pipenv install --system --dev
+    pipenv install --system --dev && \
+    apk del --no-cache .deps && \
+    apk add --no-cache libpq libjpeg zlib
+
+COPY config.yaml ./
+COPY ./src ./src
 
 ENTRYPOINT ["sh", "docker-entrypoint.sh"]


### PR DESCRIPTION
Reduce the size of the development backend image from 839 MB to 181 MB.